### PR TITLE
Actions のタグプッシュの条件を修正

### DIFF
--- a/.github/workflows/job_release.yml
+++ b/.github/workflows/job_release.yml
@@ -14,7 +14,7 @@ jobs:
   push_dockerhub:
     runs-on: ubuntu-latest
     environment: production
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') || github.event_name == 'create' && github.event.ref_type == 'tag'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/'))
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Summary

修正前の条件では、pushイベントとcreateイベントの両方をトリガーとしていますが、createイベントは新しいタグが作成されたときにのみトリガーされるため、タグがプッシュされたときにジョブを実行するために、pushイベントをトリガーとして使用し、そのrefsをチェックするように修正。

# Issue

- https://github.com/ystk-kai/snowlhive/issues/2
