### PR TITLE
出力ファイルサイズ制限オプションを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ snowlhive [OPTIONS] INPUT_DIR
 | --remove-codeblock   | Markdown のコードブロックを削除します。                               | false                |
 | --remove-url         | URL を削除します。                                                    | false                |
 | --disabled-gitignore | .gitignore ファイルで指定されたファイルを無視する設定を無効化します。 | false                |
+| --max-size           | 出力ファイルの最大サイズをバイト単位で指定します。                    | (なし)               |

--- a/src/size_utils.rs
+++ b/src/size_utils.rs
@@ -1,0 +1,57 @@
+/// 人間が読みやすいファイルサイズの文字列を解析してサイズをバイトで返す
+///
+/// この関数は、"KB"、"MB"、"GB"の接尾辞をサポートしており、大文字小文字を区別しません。
+/// 文字列が認識された接尾辞で終わっている場合、その前の部分はu64値として解析され、
+/// それから適切な1024のべき乗で乗算されます。
+/// 文字列が認識された接尾辞で終わっていない場合、それは単純なu64値として解析されます。
+///
+/// # Arguments
+///
+/// * `size_str` - 人間が読みやすいファイルサイズを保持する文字列スライス。
+///
+/// # Returns
+///
+/// * `Some(u64)` - 入力文字列が有効な場合、解析されたサイズ（バイト）。
+/// * `None` - 入力文字列が無効な場合（例："10 XB"）。
+///
+/// # Examples
+///
+/// ```
+/// let size_in_bytes = parse_human_readable_size("10 MB");
+/// assert_eq!(size_in_bytes, Some(10 * 1024 * 1024));
+/// ```
+pub fn parse_human_readable_size(size_str: &str) -> Option<u64> {
+    let suffixes = [
+        ("KB", 1024u64),
+        ("MB", 1024u64 * 1024),
+        ("GB", 1024u64 * 1024 * 1024),
+    ];
+    let size_str = size_str.trim().to_uppercase();
+
+    for (suffix, multiplier) in suffixes.iter() {
+        if size_str.ends_with(suffix) {
+            let value_str = size_str.trim_end_matches(suffix).trim();
+            if let Ok(value) = value_str.parse::<u64>() {
+                return Some(value * multiplier);
+            } else {
+                return None;
+            }
+        }
+    }
+
+    size_str.parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_human_readable_size() {
+        assert_eq!(parse_human_readable_size("10 KB"), Some(10 * 1024));
+        assert_eq!(parse_human_readable_size("10 MB"), Some(10 * 1024 * 1024));
+        assert_eq!(parse_human_readable_size("10 GB"), Some(10 * 1024 * 1024 * 1024));
+        assert_eq!(parse_human_readable_size("10"), Some(10));
+        assert_eq!(parse_human_readable_size("10 XB"), None);
+    }
+}

--- a/src/text_combiner.rs
+++ b/src/text_combiner.rs
@@ -1,35 +1,45 @@
 use std::fs;
 use std::path::Path;
 
-/// 指定されたファイルの内容を結合
+/// 指定されたファイルの内容を結合し、必要に応じて指定された最大サイズに達した場合に新しいファイルを開始
 ///
 /// Args:
 ///     files: 結合するファイルのパス一覧
 ///     input_dir: ファイルのルートディレクトリ
+///     max_size: 結合するテキストの最大サイズ（バイト単位、オプション）
 ///
 /// Returns:
-///     結合したテキスト
-pub fn combine_files(files: &mut [String], input_dir: &str) -> String {
-    let mut combined_text = String::new();
+///     結合したテキストのベクター。サイズ制限が指定されていない場合はベクターに1つの要素のみが含まれる
+pub fn combine_files(files: &mut [String], input_dir: &str, max_size: Option<u64>) -> Vec<String> {
+    let mut combined_texts = Vec::new();
+    let mut current_text = String::new();
     files.sort();
 
     for file_path in files {
         let path = Path::new(file_path);
         if let Ok(text) = fs::read_to_string(path) {
-            // ルートディレクトリからの相対パスを計算
             let relative_path = path
                 .strip_prefix(input_dir)
                 .unwrap_or(path)
                 .to_string_lossy();
 
-            // 区切り文字とファイルのパスを挿入
-            combined_text.push_str(&format!("--- File: {} ---\n\n", relative_path));
-            // ファイルの内容を追加
-            combined_text.push_str(&text);
-            // ファイル間の区切りとして改行を追加
-            combined_text.push('\n');
+            let text_with_header = format!("--- File: {} ---\n\n{}", relative_path, text);
+
+            // サイズ制限が指定されている場合、サイズをチェックする
+            if let Some(max_size) = max_size {
+                if current_text.len() + text_with_header.len() > max_size as usize {
+                    combined_texts.push(current_text);
+                    current_text = String::new();
+                }
+            }
+
+            current_text.push_str(&text_with_header);
         }
     }
 
-    combined_text
+    if !current_text.is_empty() {
+        combined_texts.push(current_text);
+    }
+
+    combined_texts
 }


### PR DESCRIPTION
# Summary

- 新たなCLIオプション`--max-size`を追加し、出力ファイルの最大サイズをバイト単位で指定できるようにしました。
- 新モジュール`size_utils`を導入し、`Cli`構造体に新たなフィールド`max_size`を追加し、新たなオプションを処理できるようにしました。
- ファイルの結合とテキストのクリーニングの処理をリファクタリングし、クリーニングオプションの定義をより明確にしました。

# Issue

- #3 
