### PR TITLE
devcontainer 内で docker compose のサービスを実行できるように修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,7 +37,7 @@ RUN curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git
     && curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash -o /usr/share/bash-completion/completions/git-completion \
     && cat /usr/share/zoneinfo/Asia/Tokyo > /etc/localtime
 
-RUN chown -R snowlhive:snowlhive /usr/local/cargo /tmp/target
+RUN chown -R $USERNAME /usr/local/cargo /tmp/target /app
 
 USER snowlhive
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while sleep 1000; do :; done"
 
+    environment:
+      PROJECT_DIR: ${PROJECT_DIR:-.}
+
 volumes:
   app-target:
   vscode-server-extensions:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target/
 
 # SnowlHive
 output/
+.env

--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ snowlhive [OPTIONS] INPUT_DIR
 | --remove-url         | URL を削除します。                                                    | false                |
 | --disabled-gitignore | .gitignore ファイルで指定されたファイルを無視する設定を無効化します。 | false                |
 | --max-size           | 出力ファイルの最大サイズをバイト単位で指定します。                    | (なし)               |
+
+## Development
+
+devcontainer を利用して開発を行う場合、以下のコマンドを実行して環境変数を設定してください。
+
+```bash
+echo "PROJECT_DIR=$(pwd)" > .env
+```


### PR DESCRIPTION
# Summary

devcontainer 内で docker compose のサービスを実行すると、マウントディレクトリは親を参照するため上手く動作しない。  
.env に `PROJECT_DIR` を設定することで解決する。