### PR TITLE
Nuxt ドキュメントのサービス追加と Actions の build を並列実行化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,8 @@
         "eamodio.gitlens",
         "bungcip.better-toml",
         "wmaurer.change-case",
-        "ryu1kn.partial-diff"
+        "ryu1kn.partial-diff",
+        "redhat.vscode-yaml"
       ]
     },
     "settings": {

--- a/.github/workflows/job_build.yml
+++ b/.github/workflows/job_build.yml
@@ -7,38 +7,161 @@ on:
         required: true
 
 jobs:
-  run_snowlhive:
+  run_rust-lang-book:
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-book
+        run: docker compose run --rm rust-lang-book
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-book
+          path: ./output/rust-lang_book.txt
 
-    - name: Create and set permissions for output directory
-      run: |
-        mkdir -p output
-        chmod 777 output
+  run_rust-lang-api-guidelines:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-api-guidelines
+        run: docker compose run --rm rust-lang-api-guidelines
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-api-guidelines
+          path: ./output/rust-lang_api-guidelines.txt
 
-    - name: Build Docker image
-      run: docker compose build
+  run_rust-lang-rfcs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-rfcs
+        run: docker compose run --rm rust-lang-rfcs
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-rfcs
+          path: ./output/rust-lang_rfcs.txt
 
-    - name: Run snowlhive
-      run: |
-        docker compose run --rm rust-lang-book
-        docker compose run --rm rust-lang-api-guidelines
-        docker compose run --rm rust-lang-rfcs
-        docker compose run --rm rust-lang-cargo
-        docker compose run --rm rust-lang-reference
-        docker compose run --rm rust-lang-this-week-in-rust
-        docker compose run --rm vercel-nextjs
+  run_rust-lang-cargo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-cargo
+        run: docker compose run --rm rust-lang-cargo
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-cargo
+          path: ./output/rust-lang_cargo.txt
 
-    - name: Cleanup
-      run: |
-        find ./output -type d -not -name 'output' -exec sudo rm -rf {} +
+  run_rust-lang-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-reference
+        run: docker compose run --rm rust-lang-reference
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-reference
+          path: ./output/rust-lang_reference.txt
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: output
-        path: ./output
+  run_rust-lang-this-week-in-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run rust-lang-this-week-in-rust
+        run: docker compose run --rm rust-lang-this-week-in-rust
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: rust-lang-this-week-in-rust
+          path: ./output/rust-lang_this-week-in-rust.txt
 
+  run_vercel-nextjs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run vercel-nextjs
+        run: docker compose run --rm vercel-nextjs
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: vercel-nextjs
+          path: ./output/vercel_nextjs.txt
+
+  run_nuxt-nuxt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker compose build dev
+      - name: Create and set permissions for output directory
+        run: mkdir -p output && chmod 777 output
+      - name: Run nuxt-nuxt
+        run: docker compose run --rm nuxt-nuxt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: nuxt-nuxt
+          path: ./output/nuxt_nuxt.txt
+
+  upload-artifact:
+    needs: 
+      - run_rust-lang-book
+      - run_rust-lang-api-guidelines
+      - run_rust-lang-rfcs
+      - run_rust-lang-cargo
+      - run_rust-lang-reference
+      - run_rust-lang-this-week-in-rust
+      - run_vercel-nextjs
+      - run_nuxt-nuxt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          path: ./output
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: ./output

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,9 @@
   ],
   "[jsonc]": {
     "editor.defaultFormatter": "dprint.dprint"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
   }
   // "rust-analyzer.inlayHints.chainingHints": false,
   // "rust-analyzer.inlayHints.parameterHints": false,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ Open AI の GPTs などで Knowledge として利用するドキュメントテ�
 - 「Snowl」はシロフクロウ（Snowly Owl）の造語で、知恵と美しい見た目を連想するように結合されたドキュメントファイルは綺麗な構造を目指します。
 - 「Hive」は蜂の巣の様にドキュメント毎に区切られた（別ファイル）となるように、ドキュメントを分割して管理します。
 
+<!-- TODO: スケジューラによる成果物の生成（見出しは英語） -->
+
+## Daily Schedule
+
+SnowlHive はデイリーで実行されるワークフローで成果物を生成します。  
+ファイルは [Releases](https://github.com/ystk-kai/snowlhive/releases) からダウンロードできます。
+
+| File Name                       | Description                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| rust-lang_book.txt              | Rust の公式ドキュメント「The Rust Programming Language」のテキストファイル。 |
+| rust-lang_api-guidelines.txt    | Rust の公式ドキュメント「API Guidelines」のテキストファイル。               |
+| rust-lang_rfcs.txt              | Rust の公式ドキュメント「RFCs」のテキストファイル。                         |
+| rust-lang_cargo.txt             | Rust の公式ドキュメント「The Cargo Book」のテキストファイル。               |
+| rust-lang_reference.txt         | Rust の公式ドキュメント「The Rust Reference」のテキストファイル。           |
+| rust-lang_this-week-in-rust.txt | Rust の公式ドキュメント「This Week in Rust」のテキストファイル。            |
+| vercel_nextjs.txt               | Vercel の公式ドキュメント「Next.js」のテキストファイル。                   |
+| nuxt_nuxt.txt                   | Nuxt の公式ドキュメント「Nuxt.js」のテキストファイル。                     |
+
+
 ## How to use SnowlHive?
 
 SnowlHive は Docker イメージとして提供します。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,5 +69,12 @@ services:
     <<: *run-snowlhive
     environment:
       OUTPUT_NAME: "vercel_nextjs.txt"
-      GIT_REPOSITORY_URL: "https://github.com/vercel/next.js"
+      GIT_REPOSITORY_URL: "https://github.com/vercel/next.js.git"
+      INPUT_PATH: "docs"
+
+  nuxt-nuxt:
+    <<: *run-snowlhive
+    environment:
+      OUTPUT_NAME: "nuxt_nuxt.txt"
+      GIT_REPOSITORY_URL: "https://github.com/nuxt/nuxt.git"
       INPUT_PATH: "docs"


### PR DESCRIPTION
# Summary

- docker compose サービスに nxut-nuxt を追加
- Actions の build に nuxt-nuxt を追加
- Actions の build を並列実行するよう修正
- devcontainer の拡張機能に `redhat.vscode-yaml` を追加
- README.md にデイリージョブの成果物の内容を記載

# Issue

- #18 
