### PR TITLE
--max-size オプションの説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ snowlhive [OPTIONS] INPUT_DIR
 | --remove-codeblock   | Markdown のコードブロックを削除します。                               | false                |
 | --remove-url         | URL を削除します。                                                    | false                |
 | --disabled-gitignore | .gitignore ファイルで指定されたファイルを無視する設定を無効化します。 | false                |
-| --max-size           | 出力ファイルの最大サイズをバイト単位で指定します。                    | (なし)               |
+| --max-size           | 出力ファイルの最大サイズをバイト単位で指定します。<br>KB、MB、GB 単位の指定も可能です。 | (なし)               |
 
 ## Development
 


### PR DESCRIPTION
# Summary

README.md の CLI Options にある `--max-size` オプションの説明に単位指定による文言が抜けていたのを修正